### PR TITLE
Update test coverage for Moodle 3.7; fixes #7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ cache:
     - $HOME/.npm
 
 php:
- - 7.0
  - 7.1
+ - 7.2
 
 env:
  global:


### PR DESCRIPTION
Add the Moodle 3.6 stable branch, drop support for PHP 7.0 on master, and add PHP 7.2 to all branches.